### PR TITLE
add webdriverio custom commands loader and example

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ file and you are all set.
 - Super simple setup
 - Full integration with [WebdriverIO](http://webdriver.io/)
 - Over 65 predefined steps that cover almost everything you need, you can start writing tests right away
+- Easy to add webdriverio commands
 - Easy integration with cloud services like [Sauce Labs](https://saucelabs.com/)
 - Support for different languages (French, Spanish, Norwegian, Polish, German, Russian)
 - _Integration of WebdriverIO's Multiremote functionality (coming soon)_
@@ -272,6 +273,11 @@ Check out all predefined snippets. You can see how they get used in [`sampleSnip
 - `/^I expect that cookie "$string"( not)* contains "$string"$/`<br>test if cookie with certain value exists
 - `/^I expect that cookie "$string"( not)* exists$/`<br>test if cookie exists
 - `/^I expect that element "$string" is( not)* \d+px (broad|tall)$/`<br>test if element has certain height/width
+
+# Adding webdriver.io custom commands
+
+You can add commands by creating a new file (*.command.js) in support/commands. All commands are auto-loaded, you can now access them directly. 
+
 
 # Contributing
 

--- a/test/features/sampleSnippets.feature
+++ b/test/features/sampleSnippets.feature
@@ -167,3 +167,8 @@ Scenario: delete cookie
     And   the cookie "test" does exist
     When  I delete the cookie "test"
     Then  I expect that cookie "test" not exists
+
+Scenario: open google with a custom command
+    Given I want to search on "http://www.google.com/"
+    Then  I expect that the url is "http://www.google.com/"
+    And   I expect that the url is not "http://yahoo.com/"

--- a/test/hooks/before.js
+++ b/test/hooks/before.js
@@ -1,13 +1,21 @@
 var WebdriverIO = require('webdriverio'),
     merge = require('deepmerge'),
-    config = require('../support/configure');
+    config = require('../support/configure')
+    glob = require("glob"),
+    path = require('path');
 
 var BeforeHook = module.exports = function(done) {
 
-    var options = config.options;
+    var options = config.options,
+    	self = this;
     options = merge(config.options, config.selenium || {});
     options.desiredCapabilities = config.capabilities;
 
     this.browser = WebdriverIO.remote(options);
+
+    glob.sync("../support/command/**/*.command.js", {cwd: path.join(__dirname)}).forEach(function(file) {
+    	require(file).call(self);
+    });
+
     this.browser.init().call(done);
 }

--- a/test/steps/given.js
+++ b/test/steps/given.js
@@ -8,6 +8,11 @@ module.exports = function() {
             var url = type === 'url' ? page : this.baseUrl + page;
             this.browser.url(url , done);
         })
+        .given(/^I want to search on "$string"$/, function(website, done){
+            this.browser
+                .visitSearchEngine(website, this)
+                .call(done);
+        })
 
         .given(/^the element "$string" is( not)* visible$/,
             require('../support/helper/isVisible.js'))

--- a/test/support/command/visitGoogle.command.js
+++ b/test/support/command/visitGoogle.command.js
@@ -1,0 +1,8 @@
+module.exports = function () {
+  this.browser.addCommand("visitSearchEngine", function(website, options) {
+    var callback = arguments[arguments.length - 1];
+
+      return this.url(website).call(callback)
+  });
+
+}


### PR DESCRIPTION
#### What's this PR do?
This add the necessary boilerplate required to autoload webdriver.io commands, those commands can then be used with cucumber.

#### Where should the reviewer start?
There is one modification in before.js to allow all custom commands to be loaded with webdriverio. 
```javascript
    glob.sync("../support/command/**/*.command.js", {cwd: path.join(__dirname)}).forEach(function(file) {
    	require(file).call(self);
    });
```
I also added a command folder in support where I added a custom command example.

#### How should this be manually tested?
I added a new test case that use a custom command to visit google.

#### Any background context you want to provide?
While I like the way you guys have setup your boilerplate, I generally use custom webdriverio commands to build my selenium tests, I found your boilerplate lacking in this area. 