### PR TITLE
Replace deprecated customFds option with stdio

### DIFF
--- a/test/run.js
+++ b/test/run.js
@@ -64,7 +64,7 @@ process.argv.slice(2).forEach(function (arg) {
 });
 
 proc = spawn(process.argv[0], args, {
-    customFds: [0, 1, 2]
+    stdio: 'inherit'
 });
 proc.on(
     'exit',


### PR DESCRIPTION
Fixes the deprecation warning which occurs when running the tests:
`(node) child_process: options.customFds option is deprecated. Use options.stdio instead.`