### PR TITLE
Allow step subdirectories

### DIFF
--- a/test/support/init.js
+++ b/test/support/init.js
@@ -16,6 +16,11 @@ var Yadda = require('yadda'),
     files = [];
 
 /**
+ * Create a reference to the support root - for easy reference within steps
+ */
+global.SUPPORT_PATH = __dirname;
+
+/**
  * expose assertion library
  */
 global.expect = chai.expect;

--- a/test/support/step-definitions.js
+++ b/test/support/step-definitions.js
@@ -2,14 +2,15 @@ var Yadda = require('yadda'),
     config = require('./configure'),
     language = Yadda.localisation[upperCaseFirstLetter(config.language)],
     fs = require('fs'),
+    glob = require('glob'),
     path = require('path'),
     chai = require('chai');
 
 module.exports = (function () {
     var library = language.library(),
         dictionary = new Yadda.Dictionary(),
-        stepsFiles = path.join(__dirname, '..', 'steps'),
-        steps = fs.readdirSync(stepsFiles);
+        stepsFiles = path.join(__dirname, '..', 'steps', '**', '*.js'),
+        steps = glob.sync(stepsFiles);
 
     /**
      * define regex helpers
@@ -20,7 +21,7 @@ module.exports = (function () {
      * define step library
      */
     steps.forEach(function (step) {
-        require(path.join(stepsFiles, step)).call(library, dictionary);
+        require(step).call(library, dictionary);
     });
 
     return library;


### PR DESCRIPTION
It would be useful to organize step definitions in sub-directories, especially as the number of steps grows. This small change allows for sub-directories within the test/steps sub-directories and only includes files with a .js extension (that seemed like a safe default?). 

I have also added a a constant that points to the absolute path of the test/support directory. The intent is that this will allow easier reference to libraries from within steps without having to keep track of the exact relative paths.