### PR TITLE
#49: Fix unclosed session problem in after hook

### DIFF
--- a/test/hooks/after.js
+++ b/test/hooks/after.js
@@ -1,3 +1,3 @@
 var AfterHook = module.exports = function (done) {
-    this.browser.end(done);
+    this.browser.end().then(done);
 };


### PR DESCRIPTION
It seems the done call in the after hook was mistakenly given as an argument to  `browser.end()` call, but should be called after the promise returns. Fixed it and works like a charm.