### PR TITLE
readme: fix and enhance 'Using tags' section

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,28 +137,27 @@ If you want to run only specific tests you can mark your features with tags. The
 Feature: ...
 ```
 
-To run only the tests with specific tag(s) use the `--tags=` parameter like so:
+To run only the tests with specific tag(s) use the `--cucumberOpts.tags=` parameter like so:
 
 Only @Tag
 ```sh
-$ wdio --cucumberOpts.tags="@Tag"
+$ wdio --cucumberOpts.tags=@Tag
 ```
 
 Not @Tag
 ```sh
-$ wdio --cucumberOpts.tags="~@Tag"
+$ wdio --cucumberOpts.tags=~@Tag
 ```
 
 @Tag1 AND @Tag2
 ```sh
-$ wdio --cucumberOpts.tags="@Tag1","Tag2"
+$ wdio --cucumberOpts.tags=@Tag1 --cucumberOpts.tags=@Tag2
 ```
 
 @Tag1 OR @Tag2
 ```sh
-$ wdio --cucumberOpts.tags="@Tag1,@Tag2"
+$ wdio --cucumberOpts.tags=@Tag1,@Tag2
 ```
-Note this currently doesn't work as intended and will translate into an AND, [see following issue](https://github.com/webdriverio/wdio-cucumber-framework/issues/53)
 
 # Pending test
 

--- a/README.md
+++ b/README.md
@@ -139,11 +139,26 @@ Feature: ...
 
 To run only the tests with specific tag(s) use the `--tags=` parameter like so:
 
+Only @Tag
 ```sh
-$ wdio --tags=@Tag,@AnotherTag
+$ wdio --cucumberOpts.tags="@Tag"
 ```
 
-You can add multiple tags separated by a comma
+Not @Tag
+```sh
+$ wdio --cucumberOpts.tags="~@Tag"
+```
+
+@Tag1 AND @Tag2
+```sh
+$ wdio --cucumberOpts.tags="@Tag1","Tag2"
+```
+
+@Tag1 OR @Tag2
+```sh
+$ wdio --cucumberOpts.tags="@Tag1,@Tag2"
+```
+Note this currently doesn't work as intended and will translate into an AND, [see following issue](https://github.com/webdriverio/wdio-cucumber-framework/issues/53)
 
 # Pending test
 


### PR DESCRIPTION
# Contribution description
The documentation is wrong for providing tags through CLI rather than in the wdio config file. I've fixed it, added more examples and also mentionned a bug in the wdio-cucumber project that makes the OR-ed tags being ADD-ed instead.

# Pull request checklist
- [*] Contributed code respects the [editorconfig rules](.editorconfig)
- [*] Contributed code passes the [eslint rules](.eslintrc.yaml)
- [*] Contributed code passes the unit tests
- [*] Added rules are described in the [readme file](README.md)
- [*] [The build](https://travis-ci.org/webdriverio/cucumber-boilerplate) of the PR is passing
