### PR TITLE
Remove babel-jest dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "webdriverio": "~4.8.0"
   },
   "devDependencies": {
-    "babel-jest": "~20.0.0",
     "babel-polyfill": "~6.23.0",
     "eslint": "~4.1.0",
     "eslint-config-airbnb-base": "~11.2.0",


### PR DESCRIPTION
# Contribution description
`babel-jest` dependency is no longer needed since now it's automatically loaded by Jest and fully integrated.

[Source](https://github.com/babel/babel-jest).
# Pull request checklist
- [x] Contributed code respects the [editorconfig rules](.editorconfig)
- [x] Contributed code passes the [eslint rules](.eslintrc.yaml)
- [x] Contributed code passes the unit tests
- [ ] Added rules are described in the [readme file](README.md)
- [ ] [The build](https://travis-ci.org/webdriverio/cucumber-boilerplate) of the PR is passing
