### PR TITLE
defineSupportCode deprecated. Require/import the individual method instead

### DIFF
--- a/src/steps/given.js
+++ b/src/steps/given.js
@@ -1,4 +1,4 @@
-import { defineSupportCode } from 'cucumber';
+const { Given } = require('cucumber');
 
 import checkContainsAnyText from '../support/check/checkContainsAnyText';
 import checkIsEmpty from '../support/check/checkIsEmpty';
@@ -22,109 +22,107 @@ import openWebsite from '../support/action/openWebsite';
 import resizeScreenSize from '../support/action/resizeScreenSize';
 
 
-defineSupportCode(({ Given }) => {
-    Given(
-        /^I open the (url|site) "([^"]*)?"$/,
-        openWebsite
-    );
+Given(
+    /^I open the (url|site) "([^"]*)?"$/,
+    openWebsite
+);
 
-    Given(
-        /^the element "([^"]*)?" is( not)* visible$/,
-        isVisible
-    );
+Given(
+    /^the element "([^"]*)?" is( not)* visible$/,
+    isVisible
+);
 
-    Given(
-        /^the element "([^"]*)?" is( not)* enabled$/,
-        isEnabled
-    );
+Given(
+    /^the element "([^"]*)?" is( not)* enabled$/,
+    isEnabled
+);
 
-    Given(
-        /^the element "([^"]*)?" is( not)* selected$/,
-        checkSelected
-    );
+Given(
+    /^the element "([^"]*)?" is( not)* selected$/,
+    checkSelected
+);
 
-    Given(
-        /^the checkbox "([^"]*)?" is( not)* checked$/,
-        checkSelected
-    );
+Given(
+    /^the checkbox "([^"]*)?" is( not)* checked$/,
+    checkSelected
+);
 
-    Given(
-        /^there is (an|no) element "([^"]*)?" on the page$/,
-        checkElementExists
-    );
+Given(
+    /^there is (an|no) element "([^"]*)?" on the page$/,
+    checkElementExists
+);
 
-    Given(
-        /^the title is( not)* "([^"]*)?"$/,
-        checkTitle
-    );
+Given(
+    /^the title is( not)* "([^"]*)?"$/,
+    checkTitle
+);
 
-    Given(
-        /^the element "([^"]*)?" contains( not)* the same text as element "([^"]*)?"$/,
-        compareText
-    );
+Given(
+    /^the element "([^"]*)?" contains( not)* the same text as element "([^"]*)?"$/,
+    compareText
+);
 
-    Given(
-        /^the (button|element) "([^"]*)?"( not)* matches the text "([^"]*)?"$/,
-        checkEqualsText
-    );
+Given(
+    /^the (button|element) "([^"]*)?"( not)* matches the text "([^"]*)?"$/,
+    checkEqualsText
+);
 
-    Given(
-        /^the (button|element) "([^"]*)?"( not)* contains the text "([^"]*)?"$/,
-        checkContainsText
-    );
+Given(
+    /^the (button|element) "([^"]*)?"( not)* contains the text "([^"]*)?"$/,
+    checkContainsText
+);
 
-    Given(
-        /^the (button|element) "([^"]*)?"( not)* contains any text$/,
-        checkContainsAnyText
-    );
+Given(
+    /^the (button|element) "([^"]*)?"( not)* contains any text$/,
+    checkContainsAnyText
+);
 
-    Given(
-        /^the (button|element) "([^"]*)?" is( not)* empty$/,
-        checkIsEmpty
-    );
+Given(
+    /^the (button|element) "([^"]*)?" is( not)* empty$/,
+    checkIsEmpty
+);
 
-    Given(
-        /^the page url is( not)* "([^"]*)?"$/,
-        checkUrl
-    );
+Given(
+    /^the page url is( not)* "([^"]*)?"$/,
+    checkUrl
+);
 
-    Given(
-        /^the( css)* attribute "([^"]*)?" from element "([^"]*)?" is( not)* "([^"]*)?"$/,
-        checkProperty
-    );
+Given(
+    /^the( css)* attribute "([^"]*)?" from element "([^"]*)?" is( not)* "([^"]*)?"$/,
+    checkProperty
+);
 
-    Given(
-        /^the cookie "([^"]*)?" contains( not)* the value "([^"]*)?"$/,
-        checkCookieContent
-    );
+Given(
+    /^the cookie "([^"]*)?" contains( not)* the value "([^"]*)?"$/,
+    checkCookieContent
+);
 
-    Given(
-        /^the cookie "([^"]*)?" does( not)* exist$/,
-        checkCookieExists
-    );
+Given(
+    /^the cookie "([^"]*)?" does( not)* exist$/,
+    checkCookieExists
+);
 
-    Given(
-        /^the element "([^"]*)?" is( not)* ([\d]+)px (broad|tall)$/,
-        checkDimension
-    );
+Given(
+    /^the element "([^"]*)?" is( not)* ([\d]+)px (broad|tall)$/,
+    checkDimension
+);
 
-    Given(
-        /^the element "([^"]*)?" is( not)* positioned at ([\d]+)px on the (x|y) axis$/,
-        checkOffset
-    );
+Given(
+    /^the element "([^"]*)?" is( not)* positioned at ([\d]+)px on the (x|y) axis$/,
+    checkOffset
+);
 
-    Given(
-        /^I have a screen that is ([\d]+) by ([\d]+) pixels$/,
-        resizeScreenSize
-    );
+Given(
+    /^I have a screen that is ([\d]+) by ([\d]+) pixels$/,
+    resizeScreenSize
+);
 
-    Given(
-        /^I have closed all but the first (window|tab)$/,
-        closeAllButFirstTab
-    );
+Given(
+    /^I have closed all but the first (window|tab)$/,
+    closeAllButFirstTab
+);
 
-    Given(
-        /^a (alertbox|confirmbox|prompt) is( not)* opened$/,
-        checkModal
-    );
-});
+Given(
+    /^a (alertbox|confirmbox|prompt) is( not)* opened$/,
+    checkModal
+);

--- a/src/steps/given.js
+++ b/src/steps/given.js
@@ -1,5 +1,3 @@
-const { Given } = require('cucumber');
-
 import checkContainsAnyText from '../support/check/checkContainsAnyText';
 import checkIsEmpty from '../support/check/checkIsEmpty';
 import checkContainsText from '../support/check/checkContainsText';
@@ -20,6 +18,8 @@ import isEnabled from '../support/check/isEnabled';
 import isVisible from '../support/check/isVisible';
 import openWebsite from '../support/action/openWebsite';
 import resizeScreenSize from '../support/action/resizeScreenSize';
+
+const { Given } = require('cucumber');
 
 
 Given(

--- a/src/steps/then.js
+++ b/src/steps/then.js
@@ -1,4 +1,4 @@
-import { defineSupportCode } from 'cucumber';
+const { Then } = require('cucumber');
 
 import checkClass from '../support/check/checkClass';
 import checkContainsAnyText from '../support/check/checkContainsAnyText';
@@ -31,154 +31,152 @@ import waitForVisible from '../support/action/waitForVisible';
 import checkIfElementExists from '../support/lib/checkIfElementExists';
 
 
-defineSupportCode(({ Then }) => {
-    Then(
-        /^I expect that the title is( not)* "([^"]*)?"$/,
-        checkTitle
-    );
+Then(
+    /^I expect that the title is( not)* "([^"]*)?"$/,
+    checkTitle
+);
 
-    Then(
-        /^I expect that element "([^"]*)?" does( not)* appear exactly "([^"]*)?" times$/,
-        checkIfElementExists
-    );
+Then(
+    /^I expect that element "([^"]*)?" does( not)* appear exactly "([^"]*)?" times$/,
+    checkIfElementExists
+);
 
-    Then(
-        /^I expect that element "([^"]*)?" is( not)* visible$/,
-        isVisible
-    );
+Then(
+    /^I expect that element "([^"]*)?" is( not)* visible$/,
+    isVisible
+);
 
-    Then(
-        /^I expect that element "([^"]*)?" becomes( not)* visible$/,
-        waitForVisible
-    );
+Then(
+    /^I expect that element "([^"]*)?" becomes( not)* visible$/,
+    waitForVisible
+);
 
-    Then(
-        /^I expect that element "([^"]*)?" is( not)* within the viewport$/,
-        checkWithinViewport
-    );
+Then(
+    /^I expect that element "([^"]*)?" is( not)* within the viewport$/,
+    checkWithinViewport
+);
 
-    Then(
-        /^I expect that element "([^"]*)?" does( not)* exist$/,
-        isExisting
-    );
+Then(
+    /^I expect that element "([^"]*)?" does( not)* exist$/,
+    isExisting
+);
 
-    Then(
-        /^I expect that element "([^"]*)?"( not)* contains the same text as element "([^"]*)?"$/,
-        compareText
-    );
+Then(
+    /^I expect that element "([^"]*)?"( not)* contains the same text as element "([^"]*)?"$/,
+    compareText
+);
 
-    Then(
-        /^I expect that (button|element) "([^"]*)?"( not)* matches the text "([^"]*)?"$/,
-        checkEqualsText
-    );
+Then(
+    /^I expect that (button|element) "([^"]*)?"( not)* matches the text "([^"]*)?"$/,
+    checkEqualsText
+);
 
-    Then(
-        /^I expect that (button|element) "([^"]*)?"( not)* contains the text "([^"]*)?"$/,
-        checkContainsText
-    );
+Then(
+    /^I expect that (button|element) "([^"]*)?"( not)* contains the text "([^"]*)?"$/,
+    checkContainsText
+);
 
-    Then(
-        /^I expect that (button|element) "([^"]*)?"( not)* contains any text$/,
-        checkContainsAnyText
-    );
+Then(
+    /^I expect that (button|element) "([^"]*)?"( not)* contains any text$/,
+    checkContainsAnyText
+);
 
-    Then(
-        /^I expect that (button|element) "([^"]*)?" is( not)* empty$/,
-        checkIsEmpty
-    );
+Then(
+    /^I expect that (button|element) "([^"]*)?" is( not)* empty$/,
+    checkIsEmpty
+);
 
-    Then(
-        /^I expect that the url is( not)* "([^"]*)?"$/,
-        checkURL
-    );
+Then(
+    /^I expect that the url is( not)* "([^"]*)?"$/,
+    checkURL
+);
 
-    Then(
-        /^I expect that the path is( not)* "([^"]*)?"$/,
-        checkURLPath
-    );
+Then(
+    /^I expect that the path is( not)* "([^"]*)?"$/,
+    checkURLPath
+);
 
-    Then(
-        /^I expect the url to( not)* contain "([^"]*)?"$/,
-        checkInURLPath
-    );
+Then(
+    /^I expect the url to( not)* contain "([^"]*)?"$/,
+    checkInURLPath
+);
 
-    Then(
-        /^I expect that the( css)* attribute "([^"]*)?" from element "([^"]*)?" is( not)* "([^"]*)?"$/,
-        checkProperty
-    );
+Then(
+    /^I expect that the( css)* attribute "([^"]*)?" from element "([^"]*)?" is( not)* "([^"]*)?"$/,
+    checkProperty
+);
 
-    Then(
-        /^I expect that checkbox "([^"]*)?" is( not)* checked$/,
-        checkSelected
-    );
+Then(
+    /^I expect that checkbox "([^"]*)?" is( not)* checked$/,
+    checkSelected
+);
 
-    Then(
-        /^I expect that element "([^"]*)?" is( not)* selected$/,
-        checkSelected
-    );
+Then(
+    /^I expect that element "([^"]*)?" is( not)* selected$/,
+    checkSelected
+);
 
-    Then(
-        /^I expect that element "([^"]*)?" is( not)* enabled$/,
-        isEnabled
-    );
+Then(
+    /^I expect that element "([^"]*)?" is( not)* enabled$/,
+    isEnabled
+);
 
-    Then(
-        /^I expect that cookie "([^"]*)?"( not)* contains "([^"]*)?"$/,
-        checkCookieContent
-    );
+Then(
+    /^I expect that cookie "([^"]*)?"( not)* contains "([^"]*)?"$/,
+    checkCookieContent
+);
 
-    Then(
-        /^I expect that cookie "([^"]*)?"( not)* exists$/,
-        checkCookieExists
-    );
+Then(
+    /^I expect that cookie "([^"]*)?"( not)* exists$/,
+    checkCookieExists
+);
 
-    Then(
-        /^I expect that element "([^"]*)?" is( not)* ([\d]+)px (broad|tall)$/,
-        checkDimension
-    );
+Then(
+    /^I expect that element "([^"]*)?" is( not)* ([\d]+)px (broad|tall)$/,
+    checkDimension
+);
 
-    Then(
-        /^I expect that element "([^"]*)?" is( not)* positioned at ([\d]+)px on the (x|y) axis$/,
-        checkOffset
-    );
+Then(
+    /^I expect that element "([^"]*)?" is( not)* positioned at ([\d]+)px on the (x|y) axis$/,
+    checkOffset
+);
 
-    Then(
-        /^I expect that element "([^"]*)?" (has|does not have) the class "([^"]*)?"$/,
-        checkClass
-    );
+Then(
+    /^I expect that element "([^"]*)?" (has|does not have) the class "([^"]*)?"$/,
+    checkClass
+);
 
-    Then(
-        /^I expect a new (window|tab) has( not)* been opened$/,
-        checkNewWindow
-    );
+Then(
+    /^I expect a new (window|tab) has( not)* been opened$/,
+    checkNewWindow
+);
 
-    Then(
-        /^I expect the url "([^"]*)?" is opened in a new (tab|window)$/,
-        checkIsOpenedInNewWindow
-    );
+Then(
+    /^I expect the url "([^"]*)?" is opened in a new (tab|window)$/,
+    checkIsOpenedInNewWindow
+);
 
-    Then(
-        /^I expect that element "([^"]*)?" is( not)* focused$/,
-        checkFocus
-    );
+Then(
+    /^I expect that element "([^"]*)?" is( not)* focused$/,
+    checkFocus
+);
 
-    Then(
-        /^I wait on element "([^"]*)?"(?: for (\d+)ms)*(?: to( not)* (be checked|be enabled|be selected|be visible|contain a text|contain a value|exist))*$/,
-        {
-            wrapperOptions: {
-                retry: 3,
-            },
+Then(
+    /^I wait on element "([^"]*)?"(?: for (\d+)ms)*(?: to( not)* (be checked|be enabled|be selected|be visible|contain a text|contain a value|exist))*$/,
+    {
+        wrapperOptions: {
+            retry: 3,
         },
-        waitFor
-    );
+    },
+    waitFor
+);
 
-    Then(
-        /^I expect that a (alertbox|confirmbox|prompt) is( not)* opened$/,
-        checkModal
-    );
+Then(
+    /^I expect that a (alertbox|confirmbox|prompt) is( not)* opened$/,
+    checkModal
+);
 
-    Then(
-        /^I expect that a (alertbox|confirmbox|prompt)( not)* contains the text "([^"]*)?"$/,
-        checkModalText
-    );
-});
+Then(
+    /^I expect that a (alertbox|confirmbox|prompt)( not)* contains the text "([^"]*)?"$/,
+    checkModalText
+);

--- a/src/steps/then.js
+++ b/src/steps/then.js
@@ -1,5 +1,3 @@
-const { Then } = require('cucumber');
-
 import checkClass from '../support/check/checkClass';
 import checkContainsAnyText from '../support/check/checkContainsAnyText';
 import checkIsEmpty from '../support/check/checkIsEmpty';
@@ -29,6 +27,8 @@ import isVisible from '../support/check/isVisible';
 import waitFor from '../support/action/waitFor';
 import waitForVisible from '../support/action/waitForVisible';
 import checkIfElementExists from '../support/lib/checkIfElementExists';
+
+const { Then } = require('cucumber');
 
 
 Then(

--- a/src/steps/when.js
+++ b/src/steps/when.js
@@ -1,4 +1,4 @@
-import { defineSupportCode } from 'cucumber';
+const { When } = require('cucumber');
 
 import clearInputField from '../support/action/clearInputField';
 import clickElement from '../support/action/clickElement';
@@ -19,89 +19,87 @@ import setPromptText from '../support/action/setPromptText';
 import submitForm from '../support/action/submitForm';
 
 
-defineSupportCode(({ When }) => {
-    When(
-        /^I (click|doubleclick) on the (link|button|element) "([^"]*)?"$/,
-        clickElement
-    );
+When(
+    /^I (click|doubleclick) on the (link|button|element) "([^"]*)?"$/,
+    clickElement
+);
 
-    When(
-        /^I (add|set) "([^"]*)?" to the inputfield "([^"]*)?"$/,
-        setInputField
-    );
+When(
+    /^I (add|set) "([^"]*)?" to the inputfield "([^"]*)?"$/,
+    setInputField
+);
 
-    When(
-        /^I clear the inputfield "([^"]*)?"$/,
-        clearInputField
-    );
+When(
+    /^I clear the inputfield "([^"]*)?"$/,
+    clearInputField
+);
 
-    When(
-        /^I drag element "([^"]*)?" to element "([^"]*)?"$/,
-        dragElement
-    );
+When(
+    /^I drag element "([^"]*)?" to element "([^"]*)?"$/,
+    dragElement
+);
 
-    When(
-        /^I submit the form "([^"]*)?"$/,
-        submitForm
-    );
+When(
+    /^I submit the form "([^"]*)?"$/,
+    submitForm
+);
 
-    When(
-        /^I pause for (\d+)ms$/,
-        pause
-    );
+When(
+    /^I pause for (\d+)ms$/,
+    pause
+);
 
-    When(
-        /^I set a cookie "([^"]*)?" with the content "([^"]*)?"$/,
-        setCookie
-    );
+When(
+    /^I set a cookie "([^"]*)?" with the content "([^"]*)?"$/,
+    setCookie
+);
 
-    When(
-        /^I delete the cookie "([^"]*)?"$/,
-        deleteCookie
-    );
+When(
+    /^I delete the cookie "([^"]*)?"$/,
+    deleteCookie
+);
 
-    When(
-        /^I press "([^"]*)?"$/,
-        pressButton
-    );
+When(
+    /^I press "([^"]*)?"$/,
+    pressButton
+);
 
-    When(
-        /^I (accept|dismiss) the (alertbox|confirmbox|prompt)$/,
-        handleModal
-    );
+When(
+    /^I (accept|dismiss) the (alertbox|confirmbox|prompt)$/,
+    handleModal
+);
 
-    When(
-        /^I enter "([^"]*)?" into the prompt$/,
-        setPromptText
-    );
+When(
+    /^I enter "([^"]*)?" into the prompt$/,
+    setPromptText
+);
 
-    When(
-        /^I scroll to element "([^"]*)?"$/,
-        scroll
-    );
+When(
+    /^I scroll to element "([^"]*)?"$/,
+    scroll
+);
 
-    When(
-        /^I close the last opened (window|tab)$/,
-        closeLastOpenedWindow
-    );
+When(
+    /^I close the last opened (window|tab)$/,
+    closeLastOpenedWindow
+);
 
-    When(
-        /^I focus the last opened (window|tab)$/,
-        focusLastOpenedWindow
-    );
+When(
+    /^I focus the last opened (window|tab)$/,
+    focusLastOpenedWindow
+);
 
-    When(
-        /^I select the (\d+)(st|nd|rd|th) option for element "([^"]*)?"$/,
-        selectOptionByIndex
-    );
+When(
+    /^I select the (\d+)(st|nd|rd|th) option for element "([^"]*)?"$/,
+    selectOptionByIndex
+);
 
-    When(
-        /^I select the option with the (name|value|text) "([^"]*)?" for element "([^"]*)?"$/,
-        selectOption
-    );
+When(
+    /^I select the option with the (name|value|text) "([^"]*)?" for element "([^"]*)?"$/,
+    selectOption
+);
 
-    When(
-        /^I move to element "([^"]*)?"(?: with an offset of (\d+),(\d+))*$/,
-        moveToElement
-    );
-});
+When(
+    /^I move to element "([^"]*)?"(?: with an offset of (\d+),(\d+))*$/,
+    moveToElement
+);

--- a/src/steps/when.js
+++ b/src/steps/when.js
@@ -1,5 +1,3 @@
-const { When } = require('cucumber');
-
 import clearInputField from '../support/action/clearInputField';
 import clickElement from '../support/action/clickElement';
 import closeLastOpenedWindow from '../support/action/closeLastOpenedWindow';
@@ -17,6 +15,8 @@ import setCookie from '../support/action/setCookie';
 import setInputField from '../support/action/setInputField';
 import setPromptText from '../support/action/setPromptText';
 import submitForm from '../support/action/submitForm';
+
+const { When } = require('cucumber');
 
 
 When(


### PR DESCRIPTION
# Contribution description
> defineSupportCode is deprecated. Require/import the individual method instead. See https://github.com/cucumber/cucumber-js/blob/master/CHANGELOG.md#400-2018-01-24 and https://github.com/webdriverio/cucumber-boilerplate/issues/211

# Pull request checklist
- [x] Contributed code respects the [editorconfig rules](.editorconfig)
- [x] Contributed code passes the [eslint rules](.eslintrc.yaml)
- [x] Contributed code passes the unit tests
- [x] Added rules are described in the [readme file](README.md)
- [x] [The build](https://travis-ci.org/webdriverio/cucumber-boilerplate) of the PR is passing
