### PR TITLE
chore: update cucumberOpts.require with wildcard

### DIFF
--- a/wdio.conf.js
+++ b/wdio.conf.js
@@ -152,6 +152,9 @@ exports.config = {
             './src/steps/given.js',
             './src/steps/then.js',
             './src/steps/when.js',
+            // Or search a (sub)folder for JS files with a wildcard
+            // works since version 1.1 of the wdio-cucumber-framework
+            './src/**/*.js',
         ],
         // <string> specify a custom snippet syntax
         snippetSyntax: undefined,

--- a/wdio.conf.js
+++ b/wdio.conf.js
@@ -154,7 +154,7 @@ exports.config = {
             './src/steps/when.js',
             // Or search a (sub)folder for JS files with a wildcard
             // works since version 1.1 of the wdio-cucumber-framework
-            './src/**/*.js',
+            //'./src/**/*.js',
         ],
         // <string> specify a custom snippet syntax
         snippetSyntax: undefined,


### PR DESCRIPTION
Lately is see a lot of questions on Gitter regarding using wildcards for `cucumberOpts.require`. This is an example
