### PR TITLE
Fix Gherkin syntax link on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Now you are ready to write your own features.
 
 # How to write a test
 
-Tests are written in [Gherkin syntax](https://cucumber.io/docs/reference)
+Tests are written in [Gherkin syntax](https://docs.cucumber.io/gherkin/reference/)
 that means that you write down what's supposed to happen in a real language. All test files are located in
 `./src/features/*` and have the file ending `.feature`. You will already find some test files in that
 directory. They should demonstrate, how tests could look like. Just create a new file and write your first


### PR DESCRIPTION
# Contribution description
> Update Gherkin syntax reference link on README.md for future generations

# Pull request checklist
- [x] Contributed code respects the [editorconfig rules](.editorconfig)
- [x] Contributed code passes the [eslint rules](.eslintrc.yaml)
- [x] Contributed code passes the unit tests
- [x] Added rules are described in the [readme file](README.md)
- [x] [The build](https://travis-ci.org/webdriverio/cucumber-boilerplate) of the PR is passing
