### PR TITLE
Fix typo

### DIFF
--- a/src/steps/then.js
+++ b/src/steps/then.js
@@ -39,7 +39,7 @@ Then(
 );
 
 Then(
-    /^I expect that the title ( not)* contains "([^"]*)?"$/,
+    /^I expect that the title( not)* contains "([^"]*)?"$/,
     checkTitleContains
 );
 


### PR DESCRIPTION
# Contribution description
> There was a typo when using `I expect that the title contains`.

# Pull request checklist
- [ ] Contributed code respects the [editorconfig rules](.editorconfig)
- [ ] Contributed code passes the [eslint rules](.eslintrc.yaml)
- [ ] Contributed code passes the unit tests
- [x] Added rules are described in the [readme file](README.md)
- [ ] [The build](https://travis-ci.org/webdriverio/cucumber-boilerplate) of the PR is passing
