### PR TITLE
move babel register to requireModule

### DIFF
--- a/wdio.conf.js
+++ b/wdio.conf.js
@@ -123,8 +123,8 @@ exports.config = {
     cucumberOpts: {
         // <boolean> show full backtrace for errors
         backtrace: false,
-        // <string[]> filetype:compiler used for processing required features
-        compiler: [],
+        // <string[]> module used for processing required features
+        requireModule: ['@babel/register'],
         // <boolean< Treat ambiguous definitions as errors
         failAmbiguousDefinitions: true,
         // <boolean> invoke formatters without executing steps
@@ -208,9 +208,8 @@ exports.config = {
     // afterHook: function afterHook() {
     // },
     //
-    beforeSession: function beforeTest() {
-        require('@babel/register');
-    },
+    // beforeSession: function beforeTest() {
+    // },
     //
     // Runs before a WebdriverIO command gets executed.
     // beforeCommand: function beforeCommand(commandName, args) {


### PR DESCRIPTION
# Contribution description

Moved `@babel/register` to `requireModule`. Works like a charm!

Note: one test was failing for me before and after the change
```
1) Drag to dropzone Then I expect that element "#draggable" is positioned at 34.5px on the x axis
Element "#draggable" should be positioned at 34.5px on the x axis, but was found at 42px: expected 42 to equal 34.5
```
Don't have time right now to take a look.

# Pull request checklist
- [x] Contributed code respects the [editorconfig rules](.editorconfig)
- [x] Contributed code passes the [eslint rules](.eslintrc.yaml)
- [ ] Contributed code passes the unit tests
- [ ] Added rules are described in the [readme file](README.md)
- [ ] [The build](https://travis-ci.org/webdriverio/cucumber-boilerplate) of the PR is passing
