### PR TITLE
fix: Correction from visible to Displayed

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ Check out all predefined snippets. You can see how they get used in [`sampleSnip
 ## Given steps
 
 - `I open the (url|site) "([^"]*)?"` <br>Open a site in the current browser window/tab
-- `the element "([^"]*)?" is( not)* visible` <br>Check the (in)visibility of an element
+- `the element "([^"]*)?" is( not)* displayed` <br>Check the (in)visibility of an element
 - `the element "([^"]*)?" is( not)* enabled` <br>Check if an element is (not) enabled
 - `the element "([^"]*)?" is( not)* selected` <br>Check if an element is (not) selected
 - `the checkbox "([^"]*)?" is( not)* checked` <br>Check if a checkbox is (not) checked


### PR DESCRIPTION
# Contribution description
> The Given command "the element "([^"]*)?" is( not)* visible" isn't correct as the step is written as "displayed" this simply changes the boilerplate command to displayed rather than visible.

# Pull request checklist
- [x] Contributed code respects the [editorconfig rules](.editorconfig)
- [x] Contributed code passes the [eslint rules](.eslintrc.yaml)
- [x] Contributed code passes the unit tests
- [x] Added rules are described in the [readme file](README.md)
- [x] [The build](https://travis-ci.org/webdriverio/cucumber-boilerplate) of the PR is passing
