### PR TITLE
Removed spaces to comply with lint

### DIFF
--- a/src/steps/then.js
+++ b/src/steps/then.js
@@ -32,7 +32,6 @@ import checkIfElementExists from '../support/lib/checkIfElementExists';
 
 const { Then } = require('cucumber');
 
-
 Then(
     /^I expect that the title is( not)* "([^"]*)?"$/,
     checkTitle

--- a/src/steps/when.js
+++ b/src/steps/when.js
@@ -17,7 +17,6 @@ import setPromptText from '../support/action/setPromptText';
 
 const { When } = require('cucumber');
 
-
 When(
     /^I (click|doubleclick) on the (link|button|element) "([^"]*)?"$/,
     clickElement


### PR DESCRIPTION
Lint fails with "More than 1 blank line not allowed ". Fixed by removing spaces.

# Contribution description
> yarn run test command fails on lint test when we have more than one space on a given file.

# Pull request checklist
- [x] Contributed code respects the [editorconfig rules](.editorconfig)
- [x] Contributed code passes the [eslint rules](.eslintrc.yaml)
- [x] Contributed code passes the unit tests
- [x] Added rules are described in the [readme file](README.md)
- [x] [The build](https://travis-ci.org/webdriverio/cucumber-boilerplate) of the PR is passing
