### PR TITLE
updated saucelabs platform configurator url

### DIFF
--- a/wdio.conf.ts
+++ b/wdio.conf.ts
@@ -46,7 +46,7 @@ export const config: WebdriverIO.Config = {
     //
     // If you have trouble getting all important capabilities together, check out the
     // Sauce Labs platform configurator - a great tool to configure your capabilities:
-    // https://docs.saucelabs.com/reference/platforms-configurator
+    // https://docs.saucelabs.com/basics/platform-configurator/
     //
     capabilities: [{
 


### PR DESCRIPTION
# Contribution description
Replaced the stale saucelabs platform configurator URL to the correct one in wdio.conf.ts

# Pull request checklist
- [x] Contributed code respects the [editorconfig rules](.editorconfig)
- [x] Contributed code passes the [eslint rules](.eslintrc.yaml)
- [x] Added rules are described in the [readme file](README.md)
