### PR TITLE
update expected title for github.com

### DIFF
--- a/src/features/githubSearch.feature
+++ b/src/features/githubSearch.feature
@@ -6,7 +6,7 @@ Feature: Github test
 Scenario: open URL
     Given I open the url "https://github.com/"
     Then  I expect the url to contain "github.com"
-    And   I expect that the title is "GitHub: Where the world builds software · GitHub"
+    And   I expect that the title is "GitHub: Let’s build from here · GitHub"
 
 Scenario: search for webdriverio repository
     Given I open the url "https://github.com/search"


### PR DESCRIPTION
# Contribution description
Looks like github.com's title has changed.

# Pull request checklist
- [x] Contributed code respects the [editorconfig rules](.editorconfig)
- [x] Contributed code passes the [eslint rules](.eslintrc.yaml)
- [x] Added rules are described in the [readme file](README.md)
