### PR TITLE
fix: Strict type checking

### DIFF
--- a/src/support/lib/checkIfElementExists.ts
+++ b/src/support/lib/checkIfElementExists.ts
@@ -26,7 +26,7 @@ export default async (
         );
     } else if (exactly) {
         expect(nrOfElements).toHaveLength(
-            exactly,
+            +exactly,
             // @ts-expect-error
             `Element with selector "${selector}" should exist exactly ${exactly} time(s)`
         );


### PR DESCRIPTION
# Contribution description
> Fixes #493 
https://github.com/webdriverio/cucumber-boilerplate/blob/002e934c24e502da4e348cb32eed9c9f2e7cf773/src/support/lib/checkIfElementExists.ts#L28-L29

The code checks for strict equality.
Whereas the `exactly` is being received as string (number "4"), so the type checking fails as the `exactly` should be a number and not a string.
Converting the `exactly` to a number.

# Pull request checklist
- [ ] Contributed code respects the [editorconfig rules](.editorconfig)
- [ ] Contributed code passes the [eslint rules](.eslintrc.yaml)
- [ ] Added rules are described in the [readme file](README.md)
